### PR TITLE
docker: add guest-direct init and baseline tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 	build-essential bc fakeroot dwarves \
 	libncurses-dev gawk flex bison openssl libssl-dev dkms libelf-dev libudev-dev libpci-dev libiberty-dev autoconf llvm \
         qemu-system ca-certificates git-core openssh-client \
+        bash coreutils util-linux findutils \
+        iproute2 kmod gzip grep sed gawk \
         libpopt-dev ncurses-dev automake autoconf git pkgconf \
         lua5.1 liblua5.1-dev libmunge-dev libwrap0-dev libcap-dev libattr1-dev \
         time \
@@ -24,6 +26,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 	vim pinentry-tty libsasl2-modules \
 	diod \
 	bonnie++ \
+        dbench postmark \
         && \
     eatmydata apt-get autoremove -y && \
     eatmydata apt-get autoclean -y && \
@@ -60,6 +63,10 @@ RUN ssh-keygen -t rsa -q -f "/opt/v9fs/.ssh/identity" -N ""
 RUN go install github.com/u-root/u-root@${UROOTVERS}
 RUN go install github.com/u-root/cpu/cmds/cpud@${CPUVERS}
 RUN go install github.com/u-root/cpu/cmds/cpu@${CPUVERS}
+USER root:root
+COPY v9fs-init /opt/v9fs/v9fs-init
+RUN chmod 0755 /opt/v9fs/v9fs-init
+USER 1000:1000
 RUN export UROOT_DIR="$(go list -f '{{.Dir}}' -m github.com/u-root/u-root@${UROOTVERS})" && \
     export CPU_DIR="$(go list -f '{{.Dir}}' -m github.com/u-root/cpu@${CPUVERS})" && \
     mkdir -p /opt/v9fs/uimage-ws && \
@@ -68,10 +75,12 @@ RUN export UROOT_DIR="$(go list -f '{{.Dir}}' -m github.com/u-root/u-root@${UROO
     GOWORK=/opt/v9fs/uimage-ws/go.work /opt/v9fs/go/bin/u-root \
       -o /opt/v9fs/initrd.cpio \
       -files /opt/v9fs/.ssh/identity.pub:key.pub \
+      -files /opt/v9fs/v9fs-init:bbin/v9fs-init \
       -files /mnt \
-      -initcmd=/bbin/cpud \
+      -initcmd=/bbin/v9fs-init \
       "$*" \
       github.com/u-root/u-root/cmds/core/{init,gosh} \
+      github.com/u-root/u-root/cmds/core/{mount,ls,mkdir,cat,echo,sleep,sync} \
       github.com/u-root/cpu/cmds/cpud
 ENV LANG="en_US.UTF-8"
 ENV MAKE="/usr/bin/make"

--- a/v9fs-init
+++ b/v9fs-init
@@ -1,0 +1,78 @@
+#!/bbin/gosh
+set -eu
+exec >/dev/console 2>&1
+
+echo "v9fs-init: boot"
+
+mkdir -p /proc /sys /dev /run /tmp /mnt/9
+
+# Best-effort mounts (some may already be mounted depending on build).
+mount -t proc proc /proc 2>/dev/null || true
+mount -t sysfs sysfs /sys 2>/dev/null || true
+mount -t devtmpfs devtmpfs /dev 2>/dev/null || true
+
+cmdline="$(cat /proc/cmdline 2>/dev/null || true)"
+
+get_karg() {
+  key="$1"
+  for tok in $cmdline; do
+    case "$tok" in
+      "$key") echo ""; return 0 ;;
+      "$key="*) echo "${tok#${key}=}"; return 0 ;;
+    esac
+  done
+  return 1
+}
+
+tests="$(get_karg v9fs.tests 2>/dev/null || true)"
+cmd="$(get_karg v9fs.cmd 2>/dev/null || true)"
+ts="$(get_karg v9fs.ts 2>/dev/null || true)"
+tag="$(get_karg v9fs.mount_tag 2>/dev/null || echo hostshare)"
+dialect="$(get_karg v9fs.dialect 2>/dev/null || echo 9p2000.L)"
+cache="$(get_karg v9fs.cache 2>/dev/null || echo loose)"
+
+echo "v9fs-init: ts=${ts:-} tests=${tests:-} cmd=${cmd:-} tag=${tag} dialect=${dialect} cache=${cache}"
+
+if [ -x /bbin/cpud ]; then
+  echo "v9fs-init: starting cpud in background"
+  /bbin/cpud &
+fi
+
+opts="trans=virtio,version=${dialect},cache=${cache}"
+if mount -t 9p -o "$opts" "$tag" /mnt/9; then
+  echo "v9fs-init: mounted hostshare at /mnt/9"
+else
+  echo "v9fs-init: ERROR: mount 9p failed (opts=$opts)"
+  echo "v9fs-init: requesting poweroff via sysrq"
+  echo o >/proc/sysrq-trigger || true
+  while :; do sleep 1; done
+fi
+
+rc=0
+if [ -n "${cmd:-}" ]; then
+  if [ -x /mnt/9/usr/sbin/chroot ] && [ -x /mnt/9/bin/bash ]; then
+    /mnt/9/usr/sbin/chroot /mnt/9 /bin/bash -lc "$cmd" || rc=$?
+  else
+    echo "v9fs-init: ERROR: missing /usr/sbin/chroot or /bin/bash in exported root"
+    rc=2
+  fi
+elif [ -n "${tests:-}" ]; then
+  disp="/home/v9fs-test/test/scripts/v9fs-guest-dispatch"
+  if [ -x "/mnt/9${disp}" ]; then
+    /mnt/9/usr/sbin/chroot /mnt/9 /bin/bash -lc "set -euo pipefail; ${disp} '$tests'" || rc=$?
+  else
+    echo "v9fs-init: ERROR: no dispatcher at ${disp} (provide v9fs.cmd=... or ship dispatcher)"
+    rc=2
+  fi
+else
+  echo "v9fs-init: nothing to run (provide v9fs.cmd=... or v9fs.tests=...)"
+fi
+
+mkdir -p /mnt/9/home/v9fs-test/test/logs 2>/dev/null || true
+echo "$rc" >/mnt/9/home/v9fs-test/test/logs/guest.exitcode 2>/dev/null || true
+
+echo "v9fs-init: requesting poweroff via sysrq"
+echo o >/proc/sysrq-trigger || true
+echo "v9fs-init: poweroff returned; idling"
+while :; do sleep 1; done
+


### PR DESCRIPTION
## Summary
- Add a `v9fs-init` u-root initcmd to the initrd to mount the virtio-9p `hostshare` export and run guest-direct commands/tests.
- Bake baseline runtime utilities into the image so the guest chroot environment is consistent (bash/chroot/mount, iproute2/kmod, gzip/grep/sed/awk, plus dbench/postmark).

## Why
`v9fs/test` currently patches the initrd and relies on a set of tools existing inside the exported container root. Moving these pieces into `v9fs/docker` reduces duplicated bootstrapping and makes guest-direct runs more deterministic.

## Test plan
- Built the image locally.
- Ran `v9fs/test` smoke flow against the locally built image (guest-direct + chroot) successfully.


Made with [Cursor](https://cursor.com)